### PR TITLE
Req/#56 user deactivation

### DIFF
--- a/account/models.py
+++ b/account/models.py
@@ -35,6 +35,8 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     is_staff = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)
     date_joined = models.DateTimeField(default=timezone.now)
+    deactivated_at = models.DateTimeField(null=True, blank=True)
+    deactivation_reason = models.TextField(null=True, blank=True)
 
     objects = CustomUserManager()
 

--- a/account/tests/integration_test/test_user_deactivation.py
+++ b/account/tests/integration_test/test_user_deactivation.py
@@ -1,73 +1,77 @@
-from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
-from django.utils import timezone
 
 User = get_user_model()
 
 
-class UserDeactivationTest(APITestCase):
+class UserDeactivationTestCase(APITestCase):
     def setUp(self):
         self.user_info = {
             "email": "testuser@example.com",
             "password": "TestPassword123!",
         }
         self.user = User.objects.create_user(**self.user_info)
-        self.url = reverse("user-deactivation")
+        self.deactivation_url = reverse("user-deactivation")
+        self.signin_url = reverse("user-signin")
 
     def test_successful_account_deactivation(self):
         # Given
         self.client.force_authenticate(user=self.user)
-
         # When
-        response = self.client.post(self.url)
+        response = self.client.post(self.deactivation_url)
 
         # Then
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.user.refresh_from_db()
         self.assertFalse(self.user.is_active)
 
-    def test_login_attempt_with_deactivated_account(self):
+    def test_fail_login_with_deactivated_account(self):
         # Given
         self.user.is_active = False
         self.user.save()
 
         # When
-        response = self.client.post(reverse("token_obtain_pair"), self.user_info)
+        response = self.client.post(self.signin_url, self.user_info)
 
         # Then
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertNotIn("access", response.data)
+        self.assertNotIn("refresh", response.data)
 
     def test_deactivation_preserves_user_data(self):
         # Given
         self.client.force_authenticate(user=self.user)
-
         # When
-        response = self.client.post(self.url)
+        self.client.post(self.deactivation_url)
 
         # Then
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(User.objects.filter(email=self.user_info["email"]).exists())
         deactivated_user = User.objects.get(email=self.user_info["email"])
         self.assertFalse(deactivated_user.is_active)
+        self.assertEqual(deactivated_user.email, self.user_info["email"])
+
+    def test_unauthorized_deactivation_attempt(self):
+        # Given
+        # User is not authenticated
+
+        # When
+        response = self.client.post(self.deactivation_url)
+
+        # Then
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_deactivation_logs_timestamp(self):
         # Given
         self.client.force_authenticate(user=self.user)
 
         # When
-        response = self.client.post(self.url)
+        response = self.client.post(self.deactivation_url)
 
         # Then
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.user.refresh_from_db()
         self.assertIsNotNone(self.user.deactivated_at)
-        self.assertAlmostEqual(
-            self.user.deactivated_at,
-            timezone.now(),
-            delta=timezone.timedelta(seconds=1),
-        )
 
     def test_deactivation_with_reason(self):
         # Given
@@ -75,31 +79,9 @@ class UserDeactivationTest(APITestCase):
         reason = "Taking a break from the platform"
 
         # When
-        response = self.client.post(self.url, {"reason": reason})
+        response = self.client.post(self.deactivation_url, {"reason": reason})
 
         # Then
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.user.refresh_from_db()
         self.assertEqual(self.user.deactivation_reason, reason)
-
-    def test_unauthorized_deactivation_attempt(self):
-        # Given
-        # User is not authenticated
-
-        # When
-        response = self.client.post(self.url)
-
-        # Then
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test_reactivation_not_allowed(self):
-        # Given
-        self.user.is_active = False
-        self.user.save()
-        self.client.force_authenticate(user=self.user)
-
-        # When
-        response = self.client.post(reverse("user-activation"))
-
-        # Then
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/account/tests/integration_test/test_user_deactivation.py
+++ b/account/tests/integration_test/test_user_deactivation.py
@@ -1,0 +1,105 @@
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from django.urls import reverse
+from rest_framework import status
+from django.utils import timezone
+
+User = get_user_model()
+
+
+class UserDeactivationTest(APITestCase):
+    def setUp(self):
+        self.user_info = {
+            "email": "testuser@example.com",
+            "password": "TestPassword123!",
+        }
+        self.user = User.objects.create_user(**self.user_info)
+        self.url = reverse("user-deactivation")
+
+    def test_successful_account_deactivation(self):
+        # Given
+        self.client.force_authenticate(user=self.user)
+
+        # When
+        response = self.client.post(self.url)
+
+        # Then
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+
+    def test_login_attempt_with_deactivated_account(self):
+        # Given
+        self.user.is_active = False
+        self.user.save()
+
+        # When
+        response = self.client.post(reverse("token_obtain_pair"), self.user_info)
+
+        # Then
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_deactivation_preserves_user_data(self):
+        # Given
+        self.client.force_authenticate(user=self.user)
+
+        # When
+        response = self.client.post(self.url)
+
+        # Then
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(User.objects.filter(email=self.user_info["email"]).exists())
+        deactivated_user = User.objects.get(email=self.user_info["email"])
+        self.assertFalse(deactivated_user.is_active)
+
+    def test_deactivation_logs_timestamp(self):
+        # Given
+        self.client.force_authenticate(user=self.user)
+
+        # When
+        response = self.client.post(self.url)
+
+        # Then
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertIsNotNone(self.user.deactivated_at)
+        self.assertAlmostEqual(
+            self.user.deactivated_at,
+            timezone.now(),
+            delta=timezone.timedelta(seconds=1),
+        )
+
+    def test_deactivation_with_reason(self):
+        # Given
+        self.client.force_authenticate(user=self.user)
+        reason = "Taking a break from the platform"
+
+        # When
+        response = self.client.post(self.url, {"reason": reason})
+
+        # Then
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.deactivation_reason, reason)
+
+    def test_unauthorized_deactivation_attempt(self):
+        # Given
+        # User is not authenticated
+
+        # When
+        response = self.client.post(self.url)
+
+        # Then
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_reactivation_not_allowed(self):
+        # Given
+        self.user.is_active = False
+        self.user.save()
+        self.client.force_authenticate(user=self.user)
+
+        # When
+        response = self.client.post(reverse("user-activation"))
+
+        # Then
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/account/urls.py
+++ b/account/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import SignUpView, SignInView
+from .views import SignUpView, SignInView, DeactivationView
 
 urlpatterns = [
     path("user-signup/", SignUpView.as_view(), name="user-signup"),
     path("user-signin/", SignInView.as_view(), name="user-signin"),
+    path("user-deactivation/", DeactivationView.as_view(), name="user-deactivation"),
 ]

--- a/account/views.py
+++ b/account/views.py
@@ -5,6 +5,9 @@ from account.serializers import UserSignUpSerializer, UserSignInSerializer
 from rest_framework.views import APIView
 from django.contrib.auth import authenticate
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework.permissions import IsAuthenticated
+from account.models import CustomUser
+from django.utils import timezone
 
 User = get_user_model()
 
@@ -48,3 +51,17 @@ class SignInView(APIView):
                 status=status.HTTP_401_UNAUTHORIZED,
             )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class DeactivationView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        user: CustomUser = request.user
+
+        user.is_active = False
+        user.deactivated_at = timezone.now()
+        user.deactivation_reason = request.data.get("reason", "")
+
+        user.save()
+        return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
## Metadata
<!-- automated -->

## 요구사항 설명
사용자가 자신의 계정을 비활성화할 수 있는 기능을 구현합니다. 비활성화된 계정은 로그인이 불가능하며, 비활성화 시점과 사유를 기록합니다.

## 작업 내용
- DeactivationView 클래스를 생성하여 계정 비활성화 로직 구현
- account/urls.py에 비활성화 API 엔드포인트 추가
- CustomUser 모델에 deactivated_at과 deactivation_reason 필드 추가
- 비활성화된 계정의 로그인 시도 시 인증 실패 처리 구현

## 발견된 버그
- 없음

## 테스트케이스
<!-- automated -->

## 스크린샷 (선택사항)
<!-- 이 기능의 경우 스크린샷이 필요하지 않아 생략합니다 -->

## 종속성 변경
<!-- automated -->

## 리뷰 포인트
- DeactivationView의 비활성화 로직이 적절한지 확인 부탁드립니다.
- 비활성화된 계정의 로그인 거부 처리가 보안적으로 적절한지 검토 부탁드립니다.
- CustomUser 모델 변경에 따른 마이그레이션 파일이 올바르게 생성되었는지 확인 부탁드립니다.